### PR TITLE
Align tracer name in metadata and ebpf program

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ sudo -E ig run ghcr.io/CHANGEME-ORG/CHANGEME-GADGET-NAME:latest
 
 ## Requirements
 
-- ig v0.25.0 (CHANGEME)
+- ig v0.26.0 (CHANGEME)
 - Linux v5.15 (CHANGEME)
 
 ## License (CHANGEME)

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -1,7 +1,7 @@
 name: 'TODO: Fill the gadget name'
 description: 'TODO: Fill the gadget description'
 tracers:
-  events:
+  changeme_mytracer:
     mapName: events
     structName: event
 structs:

--- a/program.bpf.c
+++ b/program.bpf.c
@@ -25,14 +25,12 @@ struct event {
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 
-GADGET_TRACER(changeme_mygadget, events, event);
+GADGET_TRACER(changeme_mytracer, events, event);
 
 SEC("tracepoint/syscalls/sys_enter_chdir")
 int tracepoint__sys_enter_chdir(struct trace_event_raw_sys_enter *ctx) {
   struct event *event;
   __u64 pid_tgid = bpf_get_current_pid_tgid();
-  __u8 comm[TASK_COMM_LEN];
-  int ret;
 
   event = gadget_reserve_buf(&events, sizeof(*event));
   if (!event)


### PR DESCRIPTION
# Align tracer name in metadata and ebpf program

After https://github.com/inspektor-gadget/inspektor-gadget/pull/2499, when building the gadget with `--update-metadata`, we will first add a new tracer to the metadata named `changeme_mytracer`, and then the build will fail because we will have two tracers:

```bash
$ make
sudo -E ./../ig image build \
        -t ghcr.io/changeme-org/changeme-gadget-name:addd0fd4f77c-dirty \
        --update-metadata .
INFO[0000] Experimental features enabled
Error: validating metadata file: 1 error occurred:
        * only one tracer is allowed


make: *** [Makefile:10: build] Error 1
```

It's because the updated metadata is now:

```yaml
name: 'TODO: Fill the gadget name'
description: 'TODO: Fill the gadget description'
tracers:
  changeme_mytracer:
    mapName: events
    structName: event
  events:
    mapName: events
    structName: event
structs:
[...]
```

NOTE: The renaming doesn't matter, it'd have been the same with `changeme_mygadget`.

## Solution

Align tracer name between metadata and eBPF code manually.

## Testing done

The build doesn't fail.

## Hold on merging

I suggest merging this PR only once https://github.com/inspektor-gadget/inspektor-gadget/pull/2499 is released in v0.26.0.